### PR TITLE
Fix checking the state of subscriber that does not exists

### DIFF
--- a/Gateway/CampaignMonitorSubscriberGateway.php
+++ b/Gateway/CampaignMonitorSubscriberGateway.php
@@ -102,6 +102,10 @@ class CampaignMonitorSubscriberGateway implements SubscriberGateway
             /** @var \CS_REST_Wrapper_Result $result A successful response will be empty */
             $result = $this->api->get($email);
 
+            if (!property_exists($result->response, 'State')) {
+                return false;
+            }
+
             switch ($status) {
                 case Subscriber::MEMBER_STATUS_UNSUBSCRIBED:
                     return (in_array($result->response->State, array('Unconfirmed', 'Unsubscribed', 'Bounced', 'Deleted')));


### PR DESCRIPTION
When the subsciber doesn't exists yet the API returns an error without a State property.